### PR TITLE
Improve compatibility and instructions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ langchain
 chromadb
 python-multipart
 langchain-community
+langchain-ollama
+langchain-chroma
+requests

--- a/test_client.py
+++ b/test_client.py
@@ -1,0 +1,23 @@
+import requests
+import sys
+
+HOST = "http://localhost:8002"
+
+
+def main(prompt: str = "Hello"):
+    try:
+        payload = {
+            "model": "mistral",
+            "messages": [{"role": "user", "content": prompt}]
+        }
+        resp = requests.post(f"{HOST}/v1/chat/completions", json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+        print(data["choices"][0]["message"]["content"])
+    except Exception as e:
+        print(f"Request failed: {e}")
+
+
+if __name__ == "__main__":
+    text = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else "Hello"
+    main(text)


### PR DESCRIPTION
## Summary
- switch to `langchain-ollama` and `langchain-chroma`
- expose `/` and `/api/tags` endpoints to satisfy clients
- better error messages when Ollama isn't running
- document new dependencies and Enchanted iOS setup
- default server port changed to 8002

## Testing
- `python -m py_compile server.py test_client.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684e4e81cb1883238662559b6285c52c